### PR TITLE
Upgrade node versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:8.1.0
 
 ENV SERVERLESS_VERSION 1.14.0
 


### PR DESCRIPTION
Serverless 1.15 builds are failing at this point.  Bump Node version on
the serverless 1.14