### PR TITLE
Move base image to python and setup py2 and py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM node:8.1.0
+FROM python:3.6.1
 
 ENV SERVERLESS_VERSION 1.17.0
 
-RUN npm install serverless@${SERVERLESS_VERSION} -g
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
 
-RUN apt-get update
-RUN apt-get install -y \
-    build-essential \
-    curl \
-    python-dev
+RUN npm install serverless@${SERVERLESS_VERSION} -g
 
 RUN mkdir /root/.aws
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN pip install \
     boto3
 
 ARG SERVERLESS_VERSION
-RUN npm install serverless@${SERVERLESS_VERSION} -g
+RUN npm install -g \
+    serverless@${SERVERLESS_VERSION} \
+    yarn
 
 RUN echo "alias ll='ls -alFh --color=auto'" >> /root/.bashrc
 RUN echo "alias l='ls -alFh --color=auto'" >> /root/.bashrc

--- a/Dockerfile-python3
+++ b/Dockerfile-python3
@@ -16,7 +16,9 @@ RUN pip install \
     boto3
 
 ARG SERVERLESS_VERSION
-RUN npm install serverless@${SERVERLESS_VERSION} -g
+RUN npm install -g \
+    serverless@${SERVERLESS_VERSION} \
+    yarn
 
 RUN echo "alias ll='ls -alFh --color=auto'" >> /root/.bashrc
 RUN echo "alias l='ls -alFh --color=auto'" >> /root/.bashrc

--- a/Dockerfile-python3
+++ b/Dockerfile-python3
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:3.6.2
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+NAME = verypossible/serverless
+VERSION = 1.19.0
+
+.PHONY:	all py2 py3 shell
+
+
+all : py2 py3
+
+py2 :
+	docker build \
+		-t $(NAME):$(VERSION) \
+		--build-arg SERVERLESS_VERSION=$(VERSION) \
+		.
+
+py3 :
+	docker build \
+		-t $(NAME)-python3:$(VERSION) \
+		-f Dockerfile-python3 \
+		--build-arg SERVERLESS_VERSION=$(VERSION) \
+		.
+
+shell :
+	docker run --rm -it $(NAME):$(VERSION) bash


### PR DESCRIPTION
Why
---

- It's easier to manage python versions be changing the base image. This
splits out Docker images by splitting Dockerfiles.

This change addresses the need by
---------------------------------

- Creating two different `Dockerfile` files, one for python2 and one for
python3
- Manage the Serverless version with a build-time argument.  This also
makes it eaiser to change versions via cli args during building.

Next Steps
----------

- Figure out how to build and push to Docker Hub automatically.
- Figure out the best way to pull the Serverless version from the
environment rather than having it hardcoded in the `Makefile`
- push updated images to Docker Hub