### PR TITLE
Update serverless and yarn versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN pip install \
 
 ARG SERVERLESS_VERSION
 RUN npm install -g \
-    serverless@${SERVERLESS_VERSION} \
-    yarn
+    serverless@${SERVERLESS_VERSION}
+
+ARG YARN_VERSION
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
 
 RUN echo "alias ll='ls -alFh --color=auto'" >> /root/.bashrc
 RUN echo "alias l='ls -alFh --color=auto'" >> /root/.bashrc

--- a/Dockerfile-python3
+++ b/Dockerfile-python3
@@ -20,8 +20,10 @@ RUN pip install \
 
 ARG SERVERLESS_VERSION
 RUN npm install -g \
-    serverless@${SERVERLESS_VERSION} \
-    yarn
+    serverless@${SERVERLESS_VERSION} 
+
+ARG YARN_VERSION
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
 
 RUN echo "alias ll='ls -alFh --color=auto'" >> /root/.bashrc
 RUN echo "alias l='ls -alFh --color=auto'" >> /root/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 NAME = verypossible/serverless
-VERSION = 1.24.0
+VERSION = 1.25.0
+SERVERLESS_VERSION = $(VERSION)
+YARN_VERSION = 1.3.2
 
 .PHONY:	all py2 py3 shell
 
@@ -9,14 +11,16 @@ all : py2 py3
 py2 :
 	docker build \
 		-t $(NAME):$(VERSION) \
-		--build-arg SERVERLESS_VERSION=$(VERSION) \
+		--build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) \
+		--build-arg YARN_VERSION=$(YARN_VERSION) \
 		.
 
 py3 :
 	docker build \
 		-t $(NAME):$(VERSION)-python3 \
 		-f Dockerfile-python3 \
-		--build-arg SERVERLESS_VERSION=$(VERSION) \
+		--build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) \
+		--build-arg YARN_VERSION=$(YARN_VERSION) \
 		.
 
 shell :

--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 Automated Docker build for the Serverless framework
 
-There are two `Dockerfile`s which are nearly the same.  One uses Python 2 base image and the other
-Python 3.
+There are two `Dockerfile`s which are nearly the same.  One uses
+Python 2 base image and the other Python 3.
 
-These images are built in Docker Cloud.  The Serverless version to build is specified as a build
-`ARG` (build argument) which is set using `--build-arg` during the `docker build` command.  To pass
-this argument, we need a Docker Cloud build hook which resides in `hooks/build`. 
+These images are built in Docker Cloud.  The Serverless version to
+build is specified as a build `ARG` (build argument) which is set
+using `--build-arg` during the `docker build` command.  To pass this
+argument, we need a Docker Cloud build hook which resides in
+`hooks/build`.
 
-In order to bump the Serverless version, the only real requirement is to change the version in the
-`hooks/build` file.  The `Makefile` also has references to the Serverless version, but this is
-really for testing the build locally.
+In order to bump the Serverless version, the only real requirement is
+to change the version in the `hooks/build` file.  The `Makefile` also
+has references to the Serverless version, but this is really for
+testing the build locally.
 
 See the following for more information on Docker Cloud build hooks:
 


### PR DESCRIPTION
_Why_?

Both were out of date

_How_?

fix the versions as env-vars in the make file
update both dockerfiles to accept the yarn version
install yarn from curl

_Side Effects_?

:fingers_crossed: no