### PR TITLE
Bump versions of Python, SLS and yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:2.7.14
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y \

--- a/Dockerfile-python3
+++ b/Dockerfile-python3
@@ -1,4 +1,4 @@
-FROM python:3.6.2
+FROM python:3.6.5
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = verypossible/serverless
-VERSION = 1.25.0
+VERSION = 1.26.1
 SERVERLESS_VERSION = $(VERSION)
-YARN_VERSION = 1.3.2
+YARN_VERSION = 1.5.1
 
 .PHONY:	all py2 py3 shell
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,19 @@ using `--build-arg` during the `docker build` command.  To pass this
 argument, we need a Docker Cloud build hook which resides in
 `hooks/build`.
 
+# Instructions for updating versions
+
 In order to bump the Serverless version, the only real requirement is
 to change the version in the `hooks/build` file.  The `Makefile` also
-has references to the Serverless version, but this is really for
-testing the build locally.
+has references to the Serverless version, _but this is really for
+testing the build locally_.
+
+My workflow is usually:
+
+- Update versions in `Makefile` and run `make build`
+- If the build works, update the versions in `hooks/build`
+- Create PR
+- On merge to `master`, Docker Hub will do the builds automatically.
 
 See the following for more information on Docker Cloud build hooks:
 

--- a/hooks/build
+++ b/hooks/build
@@ -10,7 +10,7 @@ fi
 echo "Using $DOCKERFILE for build"
 
 docker build \
-        --build-arg SERVERLESS_VERSION=1.25.0 \
-        --build-arg YARN_VERSION=1.3.2 \
+        --build-arg SERVERLESS_VERSION=1.26.1 \
+        --build-arg YARN_VERSION=1.5.1 \
         -f $DOCKERFILE \
         -t $IMAGE_NAME .


### PR DESCRIPTION
Why
---

- Updating to the latest and greatest of everything

This change addresses the need by
---------------------------------

- Bumping base versions of Python 2 and 3 images
- Bumping version of Serverless
- Bumping version of Yarn
- Updating README