### PR TITLE
Bump versions and set default to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:3.6.5
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y \

--- a/Dockerfile-python2
+++ b/Dockerfile-python2
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:2.7.14
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y \
@@ -20,7 +20,7 @@ RUN pip install \
 
 ARG SERVERLESS_VERSION
 RUN npm install -g \
-    serverless@${SERVERLESS_VERSION} 
+    serverless@${SERVERLESS_VERSION}
 
 ARG YARN_VERSION
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = verypossible/serverless
-VERSION = 1.26.1
+VERSION = 1.27.2
 SERVERLESS_VERSION = $(VERSION)
-YARN_VERSION = 1.5.1
+YARN_VERSION = 1.6.0
 
 .PHONY:	all py2 py3 shell
 
@@ -10,21 +10,22 @@ all : py2 py3
 
 py2 :
 	docker build \
-		-t $(NAME):$(VERSION) \
+		-t $(NAME):$(VERSION)-python2 \
+		-f Dockerfile-python2 \
 		--build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) \
 		--build-arg YARN_VERSION=$(YARN_VERSION) \
 		.
 
 py3 :
 	docker build \
-		-t $(NAME):$(VERSION)-python3 \
-		-f Dockerfile-python3 \
+		-t $(NAME):$(VERSION) \
+		-f Dockerfile \
 		--build-arg SERVERLESS_VERSION=$(SERVERLESS_VERSION) \
 		--build-arg YARN_VERSION=$(YARN_VERSION) \
 		.
 
 py2-shell :
-	docker run --rm -it $(NAME):$(VERSION) bash
+	docker run --rm -it $(NAME):$(VERSION)-python2 bash
 
 py3-shell :
-	docker run --rm -it $(NAME):$(VERSION)-python3 bash
+	docker run --rm -it $(NAME):$(VERSION) bash

--- a/hooks/build
+++ b/hooks/build
@@ -3,14 +3,14 @@ DOCKERFILE=Dockerfile
 
 echo "Building $CACHE_TAG using build hook!"
 
-if [[ $CACHE_TAG == *"python3"* ]]; then
-    DOCKERFILE=Dockerfile-python3
+if [[ $CACHE_TAG == *"python2"* ]]; then
+    DOCKERFILE=Dockerfile-python2
 fi
 
 echo "Using $DOCKERFILE for build"
 
 docker build \
-        --build-arg SERVERLESS_VERSION=1.26.1 \
-        --build-arg YARN_VERSION=1.5.1 \
+        --build-arg SERVERLESS_VERSION=1.27.2 \
+        --build-arg YARN_VERSION=1.6.0 \
         -f $DOCKERFILE \
         -t $IMAGE_NAME .


### PR DESCRIPTION
Why
---

- Update to latest versions and set the default image to python3

This change addresses the need by
---------------------------------

- Changing version numbers
- Setting default `Docker` file to python3
- Changing build commands to use Python3 image by default, and set up so
naming defaults to `python3`